### PR TITLE
Fixed the disappearance of search bar while in small screen width resolution

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,7 +13,7 @@ import Link from 'next/link'
 
 export default function Header({ sidebarSwitch }) {
   return (
-    <header className="px-4 py-2.5 flex justify-between items-center gap-32">
+    <header className="px-4 py-2.5 flex justify-between items-center gap-4 md:gap-32">
       <section className="flex items-center gap-5">
 
         <button onClick={sidebarSwitch}>
@@ -31,7 +31,7 @@ export default function Header({ sidebarSwitch }) {
         </Link>
       </section>
 
-      <section className="hidden md:flex flex-grow gap-3">
+      <section className="flex md:flex flex-grow gap-3">
         <div className="flex border border-zinc-800 pl-5 rounded-full overflow-hidden w-full">
           <input
             type="text"
@@ -55,7 +55,7 @@ export default function Header({ sidebarSwitch }) {
           <SignInButton mode="modal">
             <button className="flex items-center px-3 py-1.5 rounded-full gap-x-1 border border-zinc-800">
               <CircleUserRound className="stroke-blue-500" />
-              <span className="text-blue-500 text-sm font-medium">Sign in</span>
+              <span className="text-blue-500 text-sm font-medium hidden md:block">Sign in</span>
             </button>
           </SignInButton>
         </SignedOut>


### PR DESCRIPTION
Issue -
Search bar disappearing on small screen width resolution, this was because by default the search bar component was set to 'hidden' for small screen width resolution.

Fixes - 
1. Removed the hidden css property in the search bar component and added flex to it.
`<section className="flex md:flex flex-grow gap-3">`
2. To avoid displacement of components, the default gap between components is set to '4', i.e in smaller screen width size.
`<header className="px-4 py-2.5 flex justify-between items-center gap-4 md:gap-32">`
3. Also, hid the 'Sign in' text in the `<SignedOut>...</SignedOut>` Component by default in small screen width size to create some space for the other components. As the screen width becomes wider, the 'Sign in' text becomes visible again.